### PR TITLE
fix: :fire: Remove a line

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,5 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
     http.HandleFunc("/", handler)
-    fmt.Println("Servidor corriendo en http://localhost:8585")
     http.ListenAndServe(":8585", nil)
 }


### PR DESCRIPTION
# Remove a line

Removed the console log line in main.go that was previously printing information during server startup.